### PR TITLE
RFC 1214 fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ fn elem_with_text(tag_name: &'static str, chars: &str) -> Element {
 }
 
 
-trait ViaXml {
+trait ViaXml where Self: Sized {
     fn to_xml(&self) -> Element;
     fn from_xml(elem: Element) -> Result<Self, &'static str>;
 }


### PR DESCRIPTION
This code will stop working on Rust 1.5. This fixes it.

You may want to release a new version on crates.io as well.