### PR TITLE
Derive Clone on all applicable types

### DIFF
--- a/src/author.rs
+++ b/src/author.rs
@@ -5,7 +5,7 @@ use ::{ElementUtils, NS, Person, ViaXml};
 
 /// [The Atom Syndication Format § The "atom:author" Element]
 /// (https://tools.ietf.org/html/rfc4287#section-4.2.1)
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Author(pub Person);
 
 

--- a/src/category.rs
+++ b/src/category.rs
@@ -5,7 +5,7 @@ use ::{ElementUtils, NS, ViaXml};
 
 /// [The Atom Syndication Format § The "atom:category" Element]
 /// (https://tools.ietf.org/html/rfc4287#section-4.2.2)
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Category {
     pub term: String,
     pub scheme: Option<String>,

--- a/src/contributor.rs
+++ b/src/contributor.rs
@@ -5,7 +5,7 @@ use ::{ElementUtils, NS, Person, ViaXml};
 
 /// [The Atom Syndication Format § The "atom:contributor" Element]
 /// (https://tools.ietf.org/html/rfc4287#section-4.2.3)
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Contributor(pub Person);
 
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -18,7 +18,7 @@ use ::{Author, Category, Contributor, ElementUtils, Feed, Link, NS, Person, ViaX
 ///     ..Default::default()
 /// };
 /// ```
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Entry {
     pub id: String,
     pub title: String,

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -20,7 +20,7 @@ use ::{Author, Category, Contributor, ElementUtils, Entry, Generator, Link, NS, 
 ///     ..Default::default()
 /// };
 /// ```
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Feed {
     pub id: String,
     pub title: String,

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -7,7 +7,7 @@ use ::{ElementUtils, NS, ViaXml};
 
 /// [The Atom Syndication Format § The "atom:generator" Element]
 /// (https://tools.ietf.org/html/rfc4287#section-4.2.4)
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Generator {
     pub name: String,
     pub uri: Option<String>,

--- a/src/link.rs
+++ b/src/link.rs
@@ -5,7 +5,7 @@ use ::{ElementUtils, NS, ViaXml};
 
 /// [The Atom Syndication Format § The "atom:link" Element]
 /// (https://tools.ietf.org/html/rfc4287#section-4.2.7)
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Link {
     pub href: String,
     pub rel: Option<String>,

--- a/src/source.rs
+++ b/src/source.rs
@@ -5,7 +5,7 @@ use ::{Author, Category, Contributor, ElementUtils, Generator, Link, NS, Person,
 
 /// [The Atom Syndication Format § The "atom:source" Element]
 /// (https://tools.ietf.org/html/rfc4287#section-4.2.11)
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Source {
     pub id: Option<String>,
     pub title: Option<String>,


### PR DESCRIPTION
I'm working on a project where I need to be able to clone the feed, and was surprised to find myself unable to do so.